### PR TITLE
Add internal and local host permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,8 @@
   "version": "0.1",
   "description": "See when WM Segment events are being tracked.",
   "permissions": [
-    "http://*.weedmaps.com/*",
-    "https://*.weedmaps.com/*",
+    "*://*.weedmaps.com/*",
+    "*://*.internal-weedmaps.com/*",
     "webRequest",
     "webRequestBlocking"
   ],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "WM Segment Event Tracker",
   "manifest_version": 2,
-  "version": "0.1",
+  "version": "0.2",
   "description": "See when WM Segment events are being tracked.",
   "permissions": [
     "*://*.weedmaps.com/*",

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
   "permissions": [
     "*://*.weedmaps.com/*",
     "*://*.internal-weedmaps.com/*",
+    "*://localhost/*",
     "webRequest",
     "webRequestBlocking"
   ],


### PR DESCRIPTION
![hofaneus](https://media.giphy.com/media/1GK2uXhGHcQ5G/giphy.gif)

This PR adds the `internal-weedmaps` domain to the manifest permissions so the extension will work on acceptance and staging, as well as `localhost` so it works when developing locally.